### PR TITLE
Fix entity claim: code internationalization and length to link.

### DIFF
--- a/src/main/java/acme/entities/claims/Claim.java
+++ b/src/main/java/acme/entities/claims/Claim.java
@@ -33,7 +33,7 @@ public class Claim extends AbstractEntity {
 
 	@Column(unique = true)
 	@NotBlank
-	@Pattern(regexp = "C-[0-9]{4}")
+	@Pattern(regexp = "C-[0-9]{4}", message = "code.il8n")
 	private String				code;
 
 	@Temporal(TemporalType.TIMESTAMP)
@@ -57,6 +57,7 @@ public class Claim extends AbstractEntity {
 	private String				email;
 
 	@URL
+	@Length(max = 255)
 	private String				link;
 
 }

--- a/src/main/java/acme/entities/claims/Claim.java
+++ b/src/main/java/acme/entities/claims/Claim.java
@@ -33,7 +33,7 @@ public class Claim extends AbstractEntity {
 
 	@Column(unique = true)
 	@NotBlank
-	@Pattern(regexp = "C-[0-9]{4}", message = "code.il8n")
+	@Pattern(regexp = "C-[0-9]{4}", message = "{validation.claim.code}")
 	private String				code;
 
 	@Temporal(TemporalType.TIMESTAMP)

--- a/src/main/webapp/WEB-INF/views/messages-en.i18n
+++ b/src/main/webapp/WEB-INF/views/messages-en.i18n
@@ -1,0 +1,11 @@
+# messages-en.i18n
+#
+# Copyright (C) 2012-2024 Rafael Corchuelo.
+#
+# In keeping with the traditional purpose of furthering education and research, it is
+# the policy of the copyright owner to permit non-commercial use and redistribution of
+# this software. It has been tested carefully, but it is not guaranteed for any particular
+# purposes.  The copyright owner does not offer any warranties or representations, nor do
+# they accept any liabilities with respect to them.
+
+validation.claim.code	= The code must be in the format 'C-' followed by four digits.

--- a/src/main/webapp/WEB-INF/views/messages-es.i18n
+++ b/src/main/webapp/WEB-INF/views/messages-es.i18n
@@ -1,0 +1,11 @@
+# messages-es.i18n
+#
+# Copyright (C) 2012-2024 Rafael Corchuelo.
+#
+# In keeping with the traditional purpose of furthering education and research, it is
+# the policy of the copyright owner to permit non-commercial use and redistribution of
+# this software. It has been tested carefully, but it is not guaranteed for any particular
+# purposes.  The copyright owner does not offer any warranties or representations, nor do
+# they accept any liabilities with respect to them.
+
+validation.claim.code	= El código debe estar en el formato 'C-' seguido de cuatro dígitos.


### PR DESCRIPTION
Added pattern message and maximum length to the link as stated by the professor.

Closes #97 